### PR TITLE
Upgrade gradle-git-properties to 2.2.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,11 +27,11 @@ repositories {
 dependencies {
   implementation gradleApi()
   implementation localGroovy()
-  implementation 'gradle.plugin.com.gorylenko.gradle-git-properties:gradle-git-properties:2.0.0'
+  implementation 'gradle.plugin.com.gorylenko.gradle-git-properties:gradle-git-properties:2.2.4'
 }
 
 group = 'com.pasam.gradle.buildinfo'
-version = '0.1.3'
+version = '0.1.4'
 
 targetCompatibility = '1.8'
 sourceCompatibility = '1.8'


### PR DESCRIPTION
This makes the plugin compatible to gradle 7

This fixes https://github.com/spasam/spring-boot-build-info/issues/2